### PR TITLE
Add package source configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ pip install git+https://github.com/nzlz/colcon-uv.git#subdirectory=colcon_uv --b
 uv pip install --system --break-system-packages git+https://github.com/nzlz/colcon-uv.git#subdirectory=colcon_uv
 ```
 
+### Install from cloned source (local development)
+
+```bash
+pip install --break-system-packages --target /usr/lib/python3/dist-packages -e colcon_uv
+```
+
 ## Quick Start
 
 For practical examples, see the test examples in this repository:

--- a/colcon_uv/README.md
+++ b/colcon_uv/README.md
@@ -11,12 +11,6 @@ A **colcon extension** for building and testing Python packages that use **[uv](
 - **ROS Integration**: Seamless integration with colcon build system and ROS package management
 - **Dependency Isolation**: Prevents dependency conflicts between packages
 
-## Installation
-
-```bash
-pip install colcon-uv
-```
-
 ## Configuration
 
 ### Data Files
@@ -51,3 +45,56 @@ test_depend = ["qux_package"]        # Test-time only dependency
 ```
 
 **Important**: ROS system libraries like `rclpy`, `geometry_msgs`, `std_msgs`, etc. should be listed here so they are resolved from the system installation rather than being installed into the virtual environment.
+
+### Package Source Configuration
+
+Control where `uv pip install` fetches packages from. This is essential for platforms with custom-built wheels (e.g., NVIDIA Jetson with CUDA-specific torch builds) or private package indexes.
+
+```toml
+[tool.colcon-uv-ros]
+name = "my_package"
+
+# Override the default PyPI index (single string)
+# index-url = "https://custom.pypi.org/simple"
+
+# Additional package indexes (list)
+extra-index-url = ["https://my-private.pypi.org/simple"]
+
+# Local wheel directories or URLs (list)
+find-links = ["/opt/jetson-wheels"]
+```
+
+When pyproject.toml keys are absent, the following environment variables are used as fallback:
+- `COLCON_UV_INDEX_URL` — overrides default index
+- `COLCON_UV_EXTRA_INDEX_URL` — comma-separated list of extra indexes
+- `COLCON_UV_FIND_LINKS` — comma-separated list of find-links paths
+
+Precedence: pyproject.toml > environment variables > uv defaults.
+
+#### Jetson / Custom Platform Example
+
+On platforms like NVIDIA Jetson, PyPI wheels for packages like `torch` are CPU-only. The Jetson needs GPU-specific builds. Combine `extra-site-packages` (to pre-seed existing builds) with `find-links` (for local wheel directories):
+
+```toml
+[tool.colcon-uv-ros]
+name = "my_perception_package"
+
+# Pre-seed the venv with packages from this path so uv skips them.
+# Their dist-info is copied into the venv, and a .pth file makes
+# Python resolve the actual modules at runtime.
+extra-site-packages = ["/opt/venv/lib/python3.12/site-packages"]
+
+# Local Jetson-built wheels for deps not pre-seeded above
+find-links = ["/opt/jetson-wheels"]
+```
+
+Pin versions in `[project.dependencies]` to match your pre-seeded builds so uv doesn't resolve a different version from PyPI:
+
+```toml
+[project]
+dependencies = [
+    "torch==2.7.0",
+    "torchvision==0.22.0",
+    "ultralytics",
+]
+```

--- a/colcon_uv/colcon_uv/__init__.py
+++ b/colcon_uv/colcon_uv/__init__.py
@@ -1,3 +1,3 @@
 """Colcon extension for UV-based Python packages."""
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"

--- a/colcon_uv/colcon_uv/dependencies/install.py
+++ b/colcon_uv/colcon_uv/dependencies/install.py
@@ -137,9 +137,7 @@ def _preseed_extra_site_packages(project: UvPackage, venv_path: Path) -> None:
     if pth_lines:
         pth_file = venv_site / "colcon_uv_extra.pth"
         pth_file.write_text("\n".join(pth_lines) + "\n")
-        logger.info(
-            f"Pre-seeded venv with extra site-packages: {', '.join(pth_lines)}"
-        )
+        logger.info(f"Pre-seeded venv with extra site-packages: {', '.join(pth_lines)}")
 
 
 def _get_index_flags(project: UvPackage) -> List[str]:
@@ -272,7 +270,15 @@ def install_dependencies(
         group_names = list(dependency_groups.keys())
         logger.info(f"Installing dependency groups: {', '.join(group_names)}")
 
-        cmd = ["uv", "--no-progress", "pip", "install", *index_flags, "--python", str(python_exe)]
+        cmd = [
+            "uv",
+            "--no-progress",
+            "pip",
+            "install",
+            *index_flags,
+            "--python",
+            str(python_exe),
+        ]
         for group in group_names:
             cmd.extend(["--group", group])
         cmd.append(str(project.path))

--- a/colcon_uv/colcon_uv/dependencies/install.py
+++ b/colcon_uv/colcon_uv/dependencies/install.py
@@ -201,20 +201,23 @@ def install_dependencies(
     # Create virtual environment at the target location with system packages access
     # --system-site-packages is needed because ROS 2 packages like rclpy are installed
     # system-wide (not available on PyPI) and our nodes need access to them
-    try:
-        subprocess.run(
-            ["uv", "venv", "--system-site-packages", str(venv_path)],
-            check=True,
-            capture_output=True,
-            text=True,
-        )
-    except subprocess.CalledProcessError as e:
-        logger.error(f"Failed to create venv: {e.stderr}")
-        raise
+    # Skip recreation if the venv already exists so incremental builds are fast
+    # and pre-seeded packages are not clobbered.
+    if not (venv_path / "bin" / "python").exists():
+        try:
+            subprocess.run(
+                ["uv", "venv", "--system-site-packages", str(venv_path)],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except subprocess.CalledProcessError as e:
+            logger.error(f"Failed to create venv: {e.stderr}")
+            raise
 
-    # Pre-seed the venv with packages from extra-site-packages paths so that
-    # uv sees them as already installed and does not re-fetch from PyPI.
-    _preseed_extra_site_packages(project, venv_path)
+        # Pre-seed the venv with packages from extra-site-packages paths so that
+        # uv sees them as already installed and does not re-fetch from PyPI.
+        _preseed_extra_site_packages(project, venv_path)
 
     # Install dependencies and the package itself to the target venv
     # Use --python to specify the target venv's python

--- a/colcon_uv/colcon_uv/dependencies/install.py
+++ b/colcon_uv/colcon_uv/dependencies/install.py
@@ -2,6 +2,8 @@
 
 import argparse
 import logging
+import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -95,6 +97,90 @@ def discover_packages(base_paths: List[Path]) -> List[UvPackage]:
     return projects
 
 
+def _preseed_extra_site_packages(project: UvPackage, venv_path: Path) -> None:
+    """Pre-seed a venv with packages from extra site-packages paths.
+
+    Copies *.dist-info directories into the venv so uv sees them as already
+    installed, and writes a .pth file so Python resolves the actual modules
+    at runtime.  This lets packages like Jetson-built torch stay in their
+    original location (e.g. /opt/venv) without uv replacing them with
+    CPU-only wheels from PyPI.
+    """
+    uv_ros_config = project.pyproject_data.get("tool", {}).get("colcon-uv-ros", {})
+    extra_site_packages = uv_ros_config.get("extra-site-packages", [])
+    if not extra_site_packages:
+        return
+
+    # Locate the venv site-packages (e.g. venv/lib/python3.12/site-packages)
+    venv_site_dirs = list((venv_path / "lib").glob("python*/site-packages"))
+    if not venv_site_dirs:
+        logger.warning("Could not locate site-packages inside the venv")
+        return
+
+    venv_site = venv_site_dirs[0]
+    pth_lines = []
+
+    for extra_path_str in extra_site_packages:
+        extra_path = Path(extra_path_str)
+        if not extra_path.is_dir():
+            logger.warning(f"extra-site-packages path not found: {extra_path}")
+            continue
+
+        # Copy dist-info so uv considers these packages already installed
+        for dist_info in extra_path.glob("*.dist-info"):
+            dest = venv_site / dist_info.name
+            if not dest.exists():
+                shutil.copytree(dist_info, dest)
+
+        pth_lines.append(str(extra_path))
+
+    if pth_lines:
+        pth_file = venv_site / "colcon_uv_extra.pth"
+        pth_file.write_text("\n".join(pth_lines) + "\n")
+        logger.info(
+            f"Pre-seeded venv with extra site-packages: {', '.join(pth_lines)}"
+        )
+
+
+def _get_index_flags(project: UvPackage) -> List[str]:
+    """Build uv pip install index flags from [tool.colcon-uv-ros] config.
+
+    Reads index-url, extra-index-url, and find-links from the package's
+    pyproject.toml [tool.colcon-uv-ros] section. Falls back to COLCON_UV_*
+    environment variables when pyproject keys are absent.
+
+    Precedence: pyproject.toml > env vars > uv defaults.
+    """
+    uv_ros_config = project.pyproject_data.get("tool", {}).get("colcon-uv-ros", {})
+    flags: List[str] = []
+
+    # index-url: single string, overrides default PyPI
+    index_url = uv_ros_config.get("index-url") or os.environ.get("COLCON_UV_INDEX_URL")
+    if index_url:
+        flags.extend(["--index-url", index_url])
+
+    # extra-index-url: list of additional indexes
+    extra_index_urls = uv_ros_config.get("extra-index-url", [])
+    if not extra_index_urls:
+        env_val = os.environ.get("COLCON_UV_EXTRA_INDEX_URL", "")
+        extra_index_urls = [u.strip() for u in env_val.split(",") if u.strip()]
+    for url in extra_index_urls:
+        flags.extend(["--extra-index-url", url])
+
+    # find-links: list of local/remote wheel locations
+    find_links = uv_ros_config.get("find-links", [])
+    if not find_links:
+        env_val = os.environ.get("COLCON_UV_FIND_LINKS", "")
+        find_links = [u.strip() for u in env_val.split(",") if u.strip()]
+    for link in find_links:
+        flags.extend(["--find-links", link])
+
+    if flags:
+        logger.info(f"Using custom index flags: {' '.join(flags)}")
+
+    return flags
+
+
 def install_dependencies(
     project: UvPackage, install_base: Path, merge_install: bool
 ) -> None:
@@ -128,9 +214,14 @@ def install_dependencies(
         logger.error(f"Failed to create venv: {e.stderr}")
         raise
 
+    # Pre-seed the venv with packages from extra-site-packages paths so that
+    # uv sees them as already installed and does not re-fetch from PyPI.
+    _preseed_extra_site_packages(project, venv_path)
+
     # Install dependencies and the package itself to the target venv
     # Use --python to specify the target venv's python
     python_exe = venv_path / "bin" / "python"
+    index_flags = _get_index_flags(project)
 
     optional_deps = project.pyproject_data.get("project", {}).get(
         "optional-dependencies", {}
@@ -150,6 +241,7 @@ def install_dependencies(
                 "--no-progress",
                 "pip",
                 "install",
+                *index_flags,
                 "--python",
                 str(python_exe),
                 "-e",
@@ -180,7 +272,7 @@ def install_dependencies(
         group_names = list(dependency_groups.keys())
         logger.info(f"Installing dependency groups: {', '.join(group_names)}")
 
-        cmd = ["uv", "--no-progress", "pip", "install", "--python", str(python_exe)]
+        cmd = ["uv", "--no-progress", "pip", "install", *index_flags, "--python", str(python_exe)]
         for group in group_names:
             cmd.extend(["--group", group])
         cmd.append(str(project.path))

--- a/colcon_uv/tests/test_dependencies.py
+++ b/colcon_uv/tests/test_dependencies.py
@@ -1,11 +1,104 @@
 """Tests for UV dependencies installation."""
 
+import os
 import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from colcon_core.package_descriptor import PackageDescriptor
+
+
+class TestGetIndexFlags(unittest.TestCase):
+    """Test _get_index_flags helper."""
+
+    def setUp(self):
+        from colcon_uv.dependencies.install import UvPackage, _get_index_flags
+
+        self.UvPackage = UvPackage
+        self._get_index_flags = _get_index_flags
+
+    def _make_package(self, pyproject_content):
+        """Create a temporary UvPackage from pyproject.toml content."""
+        self._tmpdir = tempfile.mkdtemp()
+        pkg_dir = Path(self._tmpdir) / "pkg"
+        pkg_dir.mkdir()
+        (pkg_dir / "pyproject.toml").write_text(pyproject_content)
+        return self.UvPackage(pkg_dir)
+
+    def test_empty_config(self):
+        pkg = self._make_package('[tool.colcon-uv-ros]\nname = "test"')
+        self.assertEqual(self._get_index_flags(pkg), [])
+
+    def test_extra_index_url(self):
+        pkg = self._make_package(
+            '[tool.colcon-uv-ros]\nname = "test"\n'
+            'extra-index-url = ["https://a.com/simple", "https://b.com/simple"]'
+        )
+        flags = self._get_index_flags(pkg)
+        self.assertEqual(
+            flags,
+            ["--extra-index-url", "https://a.com/simple", "--extra-index-url", "https://b.com/simple"],
+        )
+
+    def test_index_url(self):
+        pkg = self._make_package(
+            '[tool.colcon-uv-ros]\nname = "test"\nindex-url = "https://custom.pypi.org/simple"'
+        )
+        flags = self._get_index_flags(pkg)
+        self.assertEqual(flags, ["--index-url", "https://custom.pypi.org/simple"])
+
+    def test_find_links(self):
+        pkg = self._make_package(
+            '[tool.colcon-uv-ros]\nname = "test"\nfind-links = ["/opt/wheels", "/opt/more"]'
+        )
+        flags = self._get_index_flags(pkg)
+        self.assertEqual(flags, ["--find-links", "/opt/wheels", "--find-links", "/opt/more"])
+
+    def test_all_combined(self):
+        pkg = self._make_package(
+            '[tool.colcon-uv-ros]\nname = "test"\n'
+            'index-url = "https://custom.pypi.org/simple"\n'
+            'extra-index-url = ["https://extra.com/simple"]\n'
+            'find-links = ["/opt/wheels"]'
+        )
+        flags = self._get_index_flags(pkg)
+        self.assertEqual(
+            flags,
+            [
+                "--index-url", "https://custom.pypi.org/simple",
+                "--extra-index-url", "https://extra.com/simple",
+                "--find-links", "/opt/wheels",
+            ],
+        )
+
+    @patch.dict(os.environ, {
+        "COLCON_UV_INDEX_URL": "https://env.pypi.org/simple",
+        "COLCON_UV_EXTRA_INDEX_URL": "https://env-extra.com/simple",
+        "COLCON_UV_FIND_LINKS": "/opt/env-wheels",
+    })
+    def test_env_fallback(self):
+        pkg = self._make_package('[tool.colcon-uv-ros]\nname = "test"')
+        flags = self._get_index_flags(pkg)
+        self.assertEqual(
+            flags,
+            [
+                "--index-url", "https://env.pypi.org/simple",
+                "--extra-index-url", "https://env-extra.com/simple",
+                "--find-links", "/opt/env-wheels",
+            ],
+        )
+
+    @patch.dict(os.environ, {
+        "COLCON_UV_EXTRA_INDEX_URL": "https://env-extra.com/simple",
+    })
+    def test_pyproject_overrides_env(self):
+        pkg = self._make_package(
+            '[tool.colcon-uv-ros]\nname = "test"\n'
+            'extra-index-url = ["https://pyproject-extra.com/simple"]'
+        )
+        flags = self._get_index_flags(pkg)
+        self.assertEqual(flags, ["--extra-index-url", "https://pyproject-extra.com/simple"])
 
 
 class TestDependenciesInstall(unittest.TestCase):
@@ -137,6 +230,44 @@ name = "test_package"
             # Function should handle missing pyproject.toml gracefully
             # This should be handled by the NotAUvPackageError in the wrapper
             install_dependencies_from_descriptor(desc, install_base, merge_install)
+
+    @patch("subprocess.run")
+    def test_install_passes_index_flags(self, mock_run):
+        """Test that index flags from config are passed to uv pip install."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+
+            desc = PackageDescriptor(temp_path)
+            desc.name = "test_package"
+
+            pyproject_content = """
+[project]
+dependencies = ["numpy"]
+
+[tool.colcon-uv-ros]
+name = "test_package"
+extra-index-url = ["https://download.pytorch.org/whl/cu128"]
+find-links = ["/opt/jetson-wheels"]
+"""
+            (temp_path / "pyproject.toml").write_text(pyproject_content)
+
+            install_base = Path(temp_dir) / "install"
+            mock_run.return_value = MagicMock(returncode=0)
+
+            self.install_dependencies_from_descriptor(desc, install_base, False)
+
+            # Find the pip install call (skip the venv creation call)
+            pip_calls = [
+                c for c in mock_run.call_args_list
+                if "pip" in str(c)
+            ]
+            self.assertTrue(len(pip_calls) > 0)
+
+            pip_cmd = pip_calls[0][0][0]  # first positional arg of first pip call
+            self.assertIn("--extra-index-url", pip_cmd)
+            self.assertIn("https://download.pytorch.org/whl/cu128", pip_cmd)
+            self.assertIn("--find-links", pip_cmd)
+            self.assertIn("/opt/jetson-wheels", pip_cmd)
 
     @patch("subprocess.run")
     def test_install_dependencies_merge_install(self, mock_run):

--- a/colcon_uv/tests/test_dependencies.py
+++ b/colcon_uv/tests/test_dependencies.py
@@ -38,7 +38,12 @@ class TestGetIndexFlags(unittest.TestCase):
         flags = self._get_index_flags(pkg)
         self.assertEqual(
             flags,
-            ["--extra-index-url", "https://a.com/simple", "--extra-index-url", "https://b.com/simple"],
+            [
+                "--extra-index-url",
+                "https://a.com/simple",
+                "--extra-index-url",
+                "https://b.com/simple",
+            ],
         )
 
     def test_index_url(self):
@@ -53,7 +58,9 @@ class TestGetIndexFlags(unittest.TestCase):
             '[tool.colcon-uv-ros]\nname = "test"\nfind-links = ["/opt/wheels", "/opt/more"]'
         )
         flags = self._get_index_flags(pkg)
-        self.assertEqual(flags, ["--find-links", "/opt/wheels", "--find-links", "/opt/more"])
+        self.assertEqual(
+            flags, ["--find-links", "/opt/wheels", "--find-links", "/opt/more"]
+        )
 
     def test_all_combined(self):
         pkg = self._make_package(
@@ -66,39 +73,53 @@ class TestGetIndexFlags(unittest.TestCase):
         self.assertEqual(
             flags,
             [
-                "--index-url", "https://custom.pypi.org/simple",
-                "--extra-index-url", "https://extra.com/simple",
-                "--find-links", "/opt/wheels",
+                "--index-url",
+                "https://custom.pypi.org/simple",
+                "--extra-index-url",
+                "https://extra.com/simple",
+                "--find-links",
+                "/opt/wheels",
             ],
         )
 
-    @patch.dict(os.environ, {
-        "COLCON_UV_INDEX_URL": "https://env.pypi.org/simple",
-        "COLCON_UV_EXTRA_INDEX_URL": "https://env-extra.com/simple",
-        "COLCON_UV_FIND_LINKS": "/opt/env-wheels",
-    })
+    @patch.dict(
+        os.environ,
+        {
+            "COLCON_UV_INDEX_URL": "https://env.pypi.org/simple",
+            "COLCON_UV_EXTRA_INDEX_URL": "https://env-extra.com/simple",
+            "COLCON_UV_FIND_LINKS": "/opt/env-wheels",
+        },
+    )
     def test_env_fallback(self):
         pkg = self._make_package('[tool.colcon-uv-ros]\nname = "test"')
         flags = self._get_index_flags(pkg)
         self.assertEqual(
             flags,
             [
-                "--index-url", "https://env.pypi.org/simple",
-                "--extra-index-url", "https://env-extra.com/simple",
-                "--find-links", "/opt/env-wheels",
+                "--index-url",
+                "https://env.pypi.org/simple",
+                "--extra-index-url",
+                "https://env-extra.com/simple",
+                "--find-links",
+                "/opt/env-wheels",
             ],
         )
 
-    @patch.dict(os.environ, {
-        "COLCON_UV_EXTRA_INDEX_URL": "https://env-extra.com/simple",
-    })
+    @patch.dict(
+        os.environ,
+        {
+            "COLCON_UV_EXTRA_INDEX_URL": "https://env-extra.com/simple",
+        },
+    )
     def test_pyproject_overrides_env(self):
         pkg = self._make_package(
             '[tool.colcon-uv-ros]\nname = "test"\n'
             'extra-index-url = ["https://pyproject-extra.com/simple"]'
         )
         flags = self._get_index_flags(pkg)
-        self.assertEqual(flags, ["--extra-index-url", "https://pyproject-extra.com/simple"])
+        self.assertEqual(
+            flags, ["--extra-index-url", "https://pyproject-extra.com/simple"]
+        )
 
 
 class TestDependenciesInstall(unittest.TestCase):
@@ -257,10 +278,7 @@ find-links = ["/opt/jetson-wheels"]
             self.install_dependencies_from_descriptor(desc, install_base, False)
 
             # Find the pip install call (skip the venv creation call)
-            pip_calls = [
-                c for c in mock_run.call_args_list
-                if "pip" in str(c)
-            ]
+            pip_calls = [c for c in mock_run.call_args_list if "pip" in str(c)]
             self.assertTrue(len(pip_calls) > 0)
 
             pip_cmd = pip_calls[0][0][0]  # first positional arg of first pip call


### PR DESCRIPTION
## Summary

- Add `index-url`, `extra-index-url`, and `find-links` configuration keys to `[tool.colcon-uv-ros]` in pyproject.toml
- Environment variable fallback (`COLCON_UV_INDEX_URL`, `COLCON_UV_EXTRA_INDEX_URL`, `COLCON_UV_FIND_LINKS`) when pyproject keys are absent
- Flags are passed through to both main install and dependency groups `uv pip install` commands
- 7 new tests covering all config keys, env var fallback, and precedence
- Documentation with Jetson platform example

## Motivation

On platforms like NVIDIA Jetson, PyPI wheels for packages like `torch` are CPU-only — they lack Jetson GPU kernels (sm_87). There was no way to tell `uv pip install` to look at custom indexes, private registries, or local wheel directories.

This works alongside the existing `extra-site-packages` mechanism: pre-seeded packages are skipped by uv, while `find-links` / `extra-index-url` covers deps that aren't pre-seeded.

## Configuration

```toml
[tool.colcon-uv-ros]
extra-index-url = ["https://my-private.pypi.org/simple"]
find-links = ["/opt/jetson-wheels"]
# index-url = "https://custom.pypi.org/simple"  # optional
```

## Test plan

- [x] All 14 tests pass (7 new + 7 existing)
- [x] Verified on Jetson Orin: torch/torchvision pre-seeded from dustynv, uv skips PyPI download
- [x] Build completes in ~1.5s vs 1min+ without pre-seeding