### PR TITLE
Resolve Python version, pass override-dependencies, fix dependency-groups cwd

### DIFF
--- a/colcon_uv/colcon_uv/__init__.py
+++ b/colcon_uv/colcon_uv/__init__.py
@@ -1,3 +1,3 @@
 """Colcon extension for UV-based Python packages."""
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"

--- a/colcon_uv/colcon_uv/dependencies/install.py
+++ b/colcon_uv/colcon_uv/dependencies/install.py
@@ -7,7 +7,7 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
 import tomli
 
@@ -198,7 +198,14 @@ def install_dependencies(
     # Venv path - this should be /install/PACKAGE_NAME/venv/
     venv_path = install_base / "venv"
 
-    # Create virtual environment at the target location with system packages access
+    # Determine the Python interpreter to use for the virtual environment.
+    # Use the same Python that is running colcon so that the venv is
+    # compatible with system-installed ROS packages (e.g. rclpy).
+    # Without this, uv may pick the highest Python version available on the
+    # system, which can cause incompatibilities with system Boost.Python,
+    # ROS packages, and other native libraries.
+    python_for_venv = sys.executable
+
     # --system-site-packages is needed because ROS 2 packages like rclpy are installed
     # system-wide (not available on PyPI) and our nodes need access to them
     # Skip recreation if the venv already exists so incremental builds are fast
@@ -206,7 +213,14 @@ def install_dependencies(
     if not (venv_path / "bin" / "python").exists():
         try:
             subprocess.run(
-                ["uv", "venv", "--system-site-packages", str(venv_path)],
+                [
+                    "uv",
+                    "venv",
+                    "--system-site-packages",
+                    "--python",
+                    python_for_venv,
+                    str(venv_path),
+                ],
                 check=True,
                 capture_output=True,
                 text=True,
@@ -284,11 +298,12 @@ def install_dependencies(
         ]
         for group in group_names:
             cmd.extend(["--group", group])
-        cmd.append(str(project.path))
+        cmd.append(".")
 
         try:
             subprocess.run(
-                cmd, check=True, stdout=sys.stdout, stderr=sys.stderr, text=True
+                cmd, check=True, stdout=sys.stdout, stderr=sys.stderr, text=True,
+                cwd=str(project.path),
             )
         except subprocess.CalledProcessError as e:
             # UV writes its errors to stderr, pass them through to user

--- a/colcon_uv/colcon_uv/dependencies/install.py
+++ b/colcon_uv/colcon_uv/dependencies/install.py
@@ -6,6 +6,7 @@ import os
 import shutil
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 from typing import List, Optional
 
@@ -241,6 +242,18 @@ def install_dependencies(
     # Skip recreation if the venv already exists so incremental builds are fast
     # and pre-seeded packages are not clobbered.
     if not (venv_path / "bin" / "python").exists():
+        # A version resolved from .python-version / requires-python may select
+        # (or download) an interpreter other than the one running colcon. Since
+        # the venv is created with --system-site-packages so ROS packages built
+        # for the system Python (e.g. rclpy) are importable, a mismatched
+        # interpreter can break those imports. Warn so the cause is visible.
+        if python_version != sys.executable:
+            logger.warning(
+                f"venv Python ({python_version}) differs from colcon's "
+                f"interpreter ({sys.executable}); with --system-site-packages, "
+                f"system ROS packages built for a different Python may fail to "
+                f"import"
+            )
         try:
             subprocess.run(
                 [
@@ -291,71 +304,36 @@ def install_dependencies(
     )
     override_file: Optional[Path] = None
     if override_deps:
-        import tempfile
-        override_file = Path(
-            tempfile.mktemp(prefix="colcon_uv_override_", suffix=".txt")
-        )
-        override_file.write_text("\n".join(override_deps) + "\n")
+        # mkstemp avoids the race/security issues of the deprecated mktemp.
+        fd, tmp_name = tempfile.mkstemp(prefix="colcon_uv_override_", suffix=".txt")
+        with os.fdopen(fd, "w") as f:
+            f.write("\n".join(override_deps) + "\n")
+        override_file = Path(tmp_name)
         override_args = ["--override", str(override_file)]
         logger.info(f"Using override-dependencies: {override_deps}")
 
+    # The override file (if any) must outlive both install calls and be removed
+    # even when an install fails -- the error paths below call sys.exit() -- so
+    # the cleanup lives in a finally block.
     try:
-        subprocess.run(
-            [
-                "uv",
-                "--no-progress",
-                "pip",
-                "install",
-                *index_flags,
-                "--python",
-                str(python_exe),
-                *override_args,
-                "-e",
-                install_target,
-            ],
-            check=True,
-            stdout=sys.stdout,
-            stderr=sys.stderr,
-            text=True,
-        )
-    except subprocess.CalledProcessError as e:
-        # UV writes its errors to stderr, pass them through to user
-        if e.stderr:
-            sys.stderr.write(e.stderr)
-            sys.stderr.flush()
-
-        # Log simply without the exception details
-        logger.error(f"Failed to install dependencies for {install_target}")
-
-        # Re-raise without the traceback by using sys.exit
-        # This prevents colcon from printing the full Python traceback
-        sys.exit(1)
-
-    # Additionally, install dependency groups (PEP 735) if present
-    dependency_groups = project.pyproject_data.get("dependency-groups", {})
-
-    if dependency_groups:
-        group_names = list(dependency_groups.keys())
-        logger.info(f"Installing dependency groups: {', '.join(group_names)}")
-
-        cmd = [
-            "uv",
-            "--no-progress",
-            "pip",
-            "install",
-            *index_flags,
-            *override_args,
-            "--python",
-            str(python_exe),
-        ]
-        for group in group_names:
-            cmd.extend(["--group", group])
-        cmd.append(".")
-
         try:
             subprocess.run(
-                cmd, check=True, stdout=sys.stdout, stderr=sys.stderr, text=True,
-                cwd=str(project.path),
+                [
+                    "uv",
+                    "--no-progress",
+                    "pip",
+                    "install",
+                    *index_flags,
+                    "--python",
+                    str(python_exe),
+                    *override_args,
+                    "-e",
+                    install_target,
+                ],
+                check=True,
+                stdout=sys.stdout,
+                stderr=sys.stderr,
+                text=True,
             )
         except subprocess.CalledProcessError as e:
             # UV writes its errors to stderr, pass them through to user
@@ -364,15 +342,58 @@ def install_dependencies(
                 sys.stderr.flush()
 
             # Log simply without the exception details
-            logger.error(f"Failed to install dependency groups for {project.name}")
+            logger.error(f"Failed to install dependencies for {install_target}")
 
             # Re-raise without the traceback by using sys.exit
             # This prevents colcon from printing the full Python traceback
             sys.exit(1)
 
-    # Clean up the temporary override file
-    if override_file and override_file.exists():
-        override_file.unlink()
+        # Additionally, install dependency groups (PEP 735) if present
+        dependency_groups = project.pyproject_data.get("dependency-groups", {})
+
+        if dependency_groups:
+            group_names = list(dependency_groups.keys())
+            logger.info(f"Installing dependency groups: {', '.join(group_names)}")
+
+            cmd = [
+                "uv",
+                "--no-progress",
+                "pip",
+                "install",
+                *index_flags,
+                *override_args,
+                "--python",
+                str(python_exe),
+            ]
+            for group in group_names:
+                cmd.extend(["--group", group])
+            cmd.append(".")
+
+            try:
+                subprocess.run(
+                    cmd,
+                    check=True,
+                    stdout=sys.stdout,
+                    stderr=sys.stderr,
+                    text=True,
+                    cwd=str(project.path),
+                )
+            except subprocess.CalledProcessError as e:
+                # UV writes its errors to stderr, pass them through to user
+                if e.stderr:
+                    sys.stderr.write(e.stderr)
+                    sys.stderr.flush()
+
+                # Log simply without the exception details
+                logger.error(f"Failed to install dependency groups for {project.name}")
+
+                # Re-raise without the traceback by using sys.exit
+                # This prevents colcon from printing the full Python traceback
+                sys.exit(1)
+    finally:
+        # Clean up the temporary override file, even on failure.
+        if override_file and override_file.exists():
+            override_file.unlink()
 
 
 def install_dependencies_from_descriptor(

--- a/colcon_uv/colcon_uv/dependencies/install.py
+++ b/colcon_uv/colcon_uv/dependencies/install.py
@@ -191,8 +191,16 @@ def _resolve_python_version(project: UvPackage) -> str:
     # 1. .python-version (uv / pyenv convention)
     python_version_file = project.path / ".python-version"
     if python_version_file.exists():
-        version = python_version_file.read_text().strip()
-        if version:
+        # uv allows several versions, one per line; the first is the primary
+        # interpreter, so use that rather than the whole (possibly multi-line)
+        # file contents.
+        versions = [
+            line.strip()
+            for line in python_version_file.read_text().splitlines()
+            if line.strip()
+        ]
+        if versions:
+            version = versions[0]
             logger.info(f"Using Python version from .python-version: {version}")
             return version
 
@@ -228,20 +236,20 @@ def install_dependencies(
     # Venv path - this should be /install/PACKAGE_NAME/venv/
     venv_path = install_base / "venv"
 
-    # Determine the Python version for the virtual environment.
-    # Priority:
-    #   1. .python-version file in the project directory (uv convention)
-    #   2. requires-python from pyproject.toml
-    #   3. sys.executable (the Python running colcon / ROS)
-    # Without an explicit version, uv defaults to the highest Python on the
-    # system, which can break Boost.Python, ROS system packages, etc.
-    python_version = _resolve_python_version(project)
-
     # --system-site-packages is needed because ROS 2 packages like rclpy are installed
     # system-wide (not available on PyPI) and our nodes need access to them
     # Skip recreation if the venv already exists so incremental builds are fast
     # and pre-seeded packages are not clobbered.
     if not (venv_path / "bin" / "python").exists():
+        # Determine the Python version for the virtual environment.
+        # Priority:
+        #   1. .python-version file in the project directory (uv convention)
+        #   2. requires-python from pyproject.toml
+        #   3. sys.executable (the Python running colcon / ROS)
+        # Without an explicit version, uv defaults to the highest Python on the
+        # system, which can break Boost.Python, ROS system packages, etc.
+        python_version = _resolve_python_version(project)
+
         # A version resolved from .python-version / requires-python may select
         # (or download) an interpreter other than the one running colcon. Since
         # the venv is created with --system-site-packages so ROS packages built
@@ -272,9 +280,12 @@ def install_dependencies(
             logger.error(f"Failed to create venv: {e.stderr}")
             raise
 
-        # Pre-seed the venv with packages from extra-site-packages paths so that
-        # uv sees them as already installed and does not re-fetch from PyPI.
-        _preseed_extra_site_packages(project, venv_path)
+    # Pre-seed the venv with packages from extra-site-packages paths so that
+    # uv sees them as already installed and does not re-fetch from PyPI. Run on
+    # every build (it is idempotent -- existing dist-info copies are skipped) so
+    # newly added extra-site-packages take effect on a rebuild without having to
+    # delete the venv first.
+    _preseed_extra_site_packages(project, venv_path)
 
     # Install dependencies and the package itself to the target venv
     # Use --python to specify the target venv's python

--- a/colcon_uv/colcon_uv/dependencies/install.py
+++ b/colcon_uv/colcon_uv/dependencies/install.py
@@ -179,6 +179,35 @@ def _get_index_flags(project: UvPackage) -> List[str]:
     return flags
 
 
+def _resolve_python_version(project: UvPackage) -> str:
+    """Resolve the Python version to use for a project's virtual environment.
+
+    Checks in order:
+      1. .python-version file in the project directory
+      2. requires-python field in pyproject.toml
+      3. The interpreter running colcon (sys.executable)
+    """
+    # 1. .python-version (uv / pyenv convention)
+    python_version_file = project.path / ".python-version"
+    if python_version_file.exists():
+        version = python_version_file.read_text().strip()
+        if version:
+            logger.info(f"Using Python version from .python-version: {version}")
+            return version
+
+    # 2. requires-python from pyproject.toml
+    requires_python = project.pyproject_data.get("project", {}).get(
+        "requires-python", ""
+    )
+    if requires_python:
+        logger.info(f"Using requires-python from pyproject.toml: {requires_python}")
+        return requires_python
+
+    # 3. Fallback to the Python running colcon
+    logger.info(f"Using colcon's Python: {sys.executable}")
+    return sys.executable
+
+
 def install_dependencies(
     project: UvPackage, install_base: Path, merge_install: bool
 ) -> None:
@@ -198,13 +227,14 @@ def install_dependencies(
     # Venv path - this should be /install/PACKAGE_NAME/venv/
     venv_path = install_base / "venv"
 
-    # Determine the Python interpreter to use for the virtual environment.
-    # Use the same Python that is running colcon so that the venv is
-    # compatible with system-installed ROS packages (e.g. rclpy).
-    # Without this, uv may pick the highest Python version available on the
-    # system, which can cause incompatibilities with system Boost.Python,
-    # ROS packages, and other native libraries.
-    python_for_venv = sys.executable
+    # Determine the Python version for the virtual environment.
+    # Priority:
+    #   1. .python-version file in the project directory (uv convention)
+    #   2. requires-python from pyproject.toml
+    #   3. sys.executable (the Python running colcon / ROS)
+    # Without an explicit version, uv defaults to the highest Python on the
+    # system, which can break Boost.Python, ROS system packages, etc.
+    python_version = _resolve_python_version(project)
 
     # --system-site-packages is needed because ROS 2 packages like rclpy are installed
     # system-wide (not available on PyPI) and our nodes need access to them
@@ -218,7 +248,7 @@ def install_dependencies(
                     "venv",
                     "--system-site-packages",
                     "--python",
-                    python_for_venv,
+                    python_version,
                     str(venv_path),
                 ],
                 check=True,

--- a/colcon_uv/colcon_uv/dependencies/install.py
+++ b/colcon_uv/colcon_uv/dependencies/install.py
@@ -249,6 +249,26 @@ def install_dependencies(
     else:
         install_target = str(project.path)
 
+    # Build override arguments from [tool.uv].override-dependencies.
+    # uv pip install does not read override-dependencies from pyproject.toml,
+    # so we materialise them into a temporary requirements file and pass it
+    # via --override.
+    override_args: List[str] = []
+    override_deps = (
+        project.pyproject_data.get("tool", {})
+        .get("uv", {})
+        .get("override-dependencies", [])
+    )
+    override_file: Optional[Path] = None
+    if override_deps:
+        import tempfile
+        override_file = Path(
+            tempfile.mktemp(prefix="colcon_uv_override_", suffix=".txt")
+        )
+        override_file.write_text("\n".join(override_deps) + "\n")
+        override_args = ["--override", str(override_file)]
+        logger.info(f"Using override-dependencies: {override_deps}")
+
     try:
         subprocess.run(
             [
@@ -259,6 +279,7 @@ def install_dependencies(
                 *index_flags,
                 "--python",
                 str(python_exe),
+                *override_args,
                 "-e",
                 install_target,
             ],
@@ -293,6 +314,7 @@ def install_dependencies(
             "pip",
             "install",
             *index_flags,
+            *override_args,
             "--python",
             str(python_exe),
         ]
@@ -317,6 +339,10 @@ def install_dependencies(
             # Re-raise without the traceback by using sys.exit
             # This prevents colcon from printing the full Python traceback
             sys.exit(1)
+
+    # Clean up the temporary override file
+    if override_file and override_file.exists():
+        override_file.unlink()
 
 
 def install_dependencies_from_descriptor(

--- a/colcon_uv/tests/test_dependencies.py
+++ b/colcon_uv/tests/test_dependencies.py
@@ -226,7 +226,9 @@ name = "test_package"
 
             # Function should handle failure gracefully without raising to caller
             try:
-                self.install_dependencies(desc, install_base, merge_install)
+                self.install_dependencies_from_descriptor(
+                    desc, install_base, merge_install
+                )
                 # If no exception raised, that's fine - graceful handling
             except CalledProcessError:
                 # If CalledProcessError propagates, that's also expected behavior

--- a/colcon_uv/tests/test_dependencies.py
+++ b/colcon_uv/tests/test_dependencies.py
@@ -1,6 +1,7 @@
 """Tests for UV dependencies installation."""
 
 import os
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -159,9 +160,14 @@ class TestResolvePythonVersion(unittest.TestCase):
         )
         self.assertEqual(self._resolve_python_version(pkg), ">=3.8,<3.11")
 
-    def test_falls_back_to_colcon_interpreter(self):
-        import sys
+    def test_multiline_python_version_uses_first(self):
+        pkg = self._make_package(
+            '[tool.colcon-uv-ros]\nname = "test"',
+            python_version_file="3.10\n3.11\n",
+        )
+        self.assertEqual(self._resolve_python_version(pkg), "3.10")
 
+    def test_falls_back_to_colcon_interpreter(self):
         pkg = self._make_package('[tool.colcon-uv-ros]\nname = "test"')
         self.assertEqual(self._resolve_python_version(pkg), sys.executable)
 
@@ -173,12 +179,10 @@ class TestDependenciesInstall(unittest.TestCase):
         """Set up test fixtures."""
         from colcon_uv.dependencies.install import (
             discover_packages,
-            install_dependencies,
             install_dependencies_from_descriptor,
         )
 
         self.discover_packages = discover_packages
-        self.install_dependencies = install_dependencies
         self.install_dependencies_from_descriptor = install_dependencies_from_descriptor
 
     def test_discover_packages_empty_directory(self):

--- a/colcon_uv/tests/test_dependencies.py
+++ b/colcon_uv/tests/test_dependencies.py
@@ -122,6 +122,50 @@ class TestGetIndexFlags(unittest.TestCase):
         )
 
 
+class TestResolvePythonVersion(unittest.TestCase):
+    """Test _resolve_python_version helper."""
+
+    def setUp(self):
+        from colcon_uv.dependencies.install import (
+            UvPackage,
+            _resolve_python_version,
+        )
+
+        self.UvPackage = UvPackage
+        self._resolve_python_version = _resolve_python_version
+
+    def _make_package(self, pyproject_content, python_version_file=None):
+        """Create a temporary UvPackage, optionally with a .python-version."""
+        self._tmpdir = tempfile.mkdtemp()
+        pkg_dir = Path(self._tmpdir) / "pkg"
+        pkg_dir.mkdir()
+        (pkg_dir / "pyproject.toml").write_text(pyproject_content)
+        if python_version_file is not None:
+            (pkg_dir / ".python-version").write_text(python_version_file)
+        return self.UvPackage(pkg_dir)
+
+    def test_python_version_file_takes_priority(self):
+        pkg = self._make_package(
+            '[project]\nrequires-python = ">=3.11"\n'
+            '[tool.colcon-uv-ros]\nname = "test"',
+            python_version_file="3.10\n",
+        )
+        self.assertEqual(self._resolve_python_version(pkg), "3.10")
+
+    def test_requires_python_when_no_version_file(self):
+        pkg = self._make_package(
+            '[project]\nrequires-python = ">=3.8,<3.11"\n'
+            '[tool.colcon-uv-ros]\nname = "test"'
+        )
+        self.assertEqual(self._resolve_python_version(pkg), ">=3.8,<3.11")
+
+    def test_falls_back_to_colcon_interpreter(self):
+        import sys
+
+        pkg = self._make_package('[tool.colcon-uv-ros]\nname = "test"')
+        self.assertEqual(self._resolve_python_version(pkg), sys.executable)
+
+
 class TestDependenciesInstall(unittest.TestCase):
     """Test UV dependencies installation functionality."""
 
@@ -288,6 +332,75 @@ find-links = ["/opt/jetson-wheels"]
             self.assertIn("https://download.pytorch.org/whl/cu128", pip_cmd)
             self.assertIn("--find-links", pip_cmd)
             self.assertIn("/opt/jetson-wheels", pip_cmd)
+
+    @patch("subprocess.run")
+    def test_install_passes_override_dependencies(self, mock_run):
+        """override-dependencies are materialised and passed via --override."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+
+            desc = PackageDescriptor(temp_path)
+            desc.name = "test_package"
+
+            pyproject_content = """
+[project]
+dependencies = ["numpy"]
+
+[tool.colcon-uv-ros]
+name = "test_package"
+
+[tool.uv]
+override-dependencies = ["numpy==1.26.4"]
+"""
+            (temp_path / "pyproject.toml").write_text(pyproject_content)
+
+            install_base = Path(temp_dir) / "install"
+            mock_run.return_value = MagicMock(returncode=0)
+
+            self.install_dependencies_from_descriptor(desc, install_base, False)
+
+            pip_calls = [c for c in mock_run.call_args_list if "pip" in str(c)]
+            pip_cmd = pip_calls[0][0][0]
+            self.assertIn("--override", pip_cmd)
+
+            # The override path must point at a written requirements file...
+            override_path = Path(pip_cmd[pip_cmd.index("--override") + 1])
+            # ...and must be cleaned up after install completes.
+            self.assertFalse(
+                override_path.exists(), "override temp file was not cleaned up"
+            )
+
+    @patch("subprocess.run")
+    def test_dependency_groups_run_in_project_cwd(self, mock_run):
+        """Dependency-group installs run from the project dir with '.' target."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+
+            desc = PackageDescriptor(temp_path)
+            desc.name = "test_package"
+
+            pyproject_content = """
+[project]
+dependencies = ["numpy"]
+
+[tool.colcon-uv-ros]
+name = "test_package"
+
+[dependency-groups]
+test = ["pytest"]
+"""
+            (temp_path / "pyproject.toml").write_text(pyproject_content)
+
+            install_base = Path(temp_dir) / "install"
+            mock_run.return_value = MagicMock(returncode=0)
+
+            self.install_dependencies_from_descriptor(desc, install_base, False)
+
+            group_calls = [c for c in mock_run.call_args_list if "--group" in str(c)]
+            self.assertEqual(len(group_calls), 1)
+            cmd = group_calls[0][0][0]
+            self.assertEqual(cmd[-1], ".")
+            self.assertEqual(group_calls[0].kwargs.get("cwd"), str(temp_path))
 
     @patch("subprocess.run")
     def test_install_dependencies_merge_install(self, mock_run):


### PR DESCRIPTION
## Summary

Carries forward @hakuturu583's three fixes from #15 (cherry-picked with authorship intact), rebased onto current `main` and hardened with tests. Fixes three independent bugs in `install_dependencies()`:

1. **Resolve the venv Python version** — closes #13. uv previously got no `--python`, so it picked the highest Python on the system regardless of `requires-python`. Now resolved in priority order: `.python-version` file → `requires-python` in `pyproject.toml` → the interpreter running colcon.
2. **Pass `[tool.uv].override-dependencies`** — `uv pip install` does not read this key from `pyproject.toml`, so overrides were silently ignored. They're now materialised into a temp requirements file and passed via `--override`.
3. **Fix dependency-groups (PEP 735) resolution** — groups are resolved relative to cwd, so the install now runs with `cwd=project.path` and a `.` target instead of passing the path positionally.

## Hardening / follow-up (on top of the cherry-picks)

- Replaced the deprecated, race-prone `tempfile.mktemp()` with `mkstemp()`, and moved override-file cleanup into a `finally` block so it no longer leaks when an install fails (the error paths call `sys.exit()`).
- Warn when the resolved venv interpreter differs from colcon's — see caveat below.
- Resolve the Python version only at venv creation (not on every incremental build); run `extra-site-packages` pre-seeding idempotently on every build so newly-added entries take effect without deleting the venv; read only the first line of a multi-line `.python-version`.
- Added tests for all three behaviors (resolver precedence, override passthrough + cleanup, dependency-groups cwd). The original branch had none.

## Caveat (by design)

Passing a `requires-python` **range** to `uv venv --python` can make uv download a managed CPython. Because the venv uses `--system-site-packages` so system ROS packages (e.g. `rclpy`) are importable, a mismatched interpreter could break those imports. This is the desired behavior for #13 (respect the requested version), so it's left as a **warning** rather than a hard block.

## Test plan

- [x] 51 unit tests pass (`pytest`)
- [x] `ruff check` and `ruff format` clean

Closes #13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)